### PR TITLE
Add four tier-specific skills (raw / analyst / copilot / explorer)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/chordcommerce/chord-copilot.git",
         "path": "plugin"
       },
-      "description": "Registers the chord-copilot MCP server and installs the data-question workflow skill."
+      "description": "Registers the chord-copilot MCP server and installs the data-question skill. Analyst mode uses get_sql_context to ground Claude's SQL in schema DDL, instructions, and examples. Copilot mode delegates to the Hub pipeline via ask for a packaged SQL + summary answer."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ claude mcp list   # chord-copilot should show as connected
 ```
 
 Then ask Claude *"How many orders did we have last month?"* — the
-`chord:copilot` skill should auto-trigger and walk through
-`search_schema` → `search_saved_views` / `search_sql_pairs` →
-`search_instructions` → draft SQL → `execute_sql`.
+`chord:copilot` skill should auto-trigger and walk through the **Analyst
+workflow**: `get_sql_context` (parallel schema DDL + SQL examples +
+instructions + memory) → `search_saved_views` → draft SQL → `execute_sql`.
+
+For a packaged answer with a natural-language summary, use **Copilot mode**:
+ask Claude to "use the Hub" or call `ask` directly — the Hub handles SQL
+generation, execution, and summarization in one call.
 
 ---
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chord",
   "version": "0.1.0",
-  "description": "MCP server registration and workflow skill for answering data questions against the Chord warehouse.",
+  "description": "MCP server registration and skill for answering data questions against the Chord warehouse. Supports Analyst mode (Claude retrieves context via get_sql_context and writes SQL) and Copilot mode (full Hub pipeline via ask).",
   "author": { "name": "Chord Commerce" },
   "homepage": "https://github.com/chordcommerce/chord-copilot"
 }

--- a/plugin/skills/analyst/SKILL.md
+++ b/plugin/skills/analyst/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: chord-analyst
-description: Answer data questions against the Chord warehouse using retrieval-grounded SQL. Use when the chord-analyst MCP server is connected (mcp__chord_analyst__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any saved/canonical query. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. Claude retrieves full context (DDL, instructions, memory, examples) before writing SQL.
+description: Answer data questions against the Chord warehouse using retrieval-grounded SQL. Use when the chord MCP server is connected (mcp__chord__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any saved/canonical query. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. Claude retrieves full context (DDL, instructions, memory, examples) before writing SQL.
 ---
 
 # Chord Analyst — retrieval-grounded SQL workflow
 
-You have access to `mcp__chord_analyst__*` tools exposed by the chord-analyst MCP
-server. Reach for them automatically — without being asked — whenever the user's
+You have access to `mcp__chord__*` tools exposed by the chord MCP server.
+Reach for them automatically — without being asked — whenever the user's
 request involves warehouse data, schema, saved queries, or product documentation.
+
+Use the Analyst-tier tools for this workflow. Do not call `ask` — that is the
+Copilot tier. Claude writes SQL here; Chord provides the context.
 
 ## Tools
 
@@ -28,8 +31,7 @@ request involves warehouse data, schema, saved queries, or product documentation
 
 - **`search_schema`** — semantic search over table descriptions. Useful for
   exploring beyond the top-k tables returned by `get_sql_context`.
-- **`search_sql_pairs`** — additional historical Q&A examples beyond what
-  `get_sql_context` returns.
+- **`search_sql_pairs`** — additional historical Q&A examples.
 - **`search_saved_views`** — canonical, user-blessed queries. Prefer an existing
   view over writing new SQL if one covers the question.
 - **`search_instructions`** — targeted instruction lookup by scope (e.g.
@@ -63,10 +65,10 @@ request involves warehouse data, schema, saved queries, or product documentation
 
 ## Failure modes
 
-- **MCP tools not available** — the `mcp__chord_analyst__*` tools are missing.
-  The chord-analyst MCP server isn't registered. Tell the user to run:
+- **MCP tools not available** — the `mcp__chord__*` tools are missing.
+  The chord MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord-analyst --transport http https://mcp.<instance>.chord.co/mcp/analyst/ --scope user
+  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
   ```
 
 - **Engine unreachable** — `execute_sql` / `preview_table` return a connection

--- a/plugin/skills/analyst/SKILL.md
+++ b/plugin/skills/analyst/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: chord-analyst
+description: Answer data questions against the Chord warehouse using retrieval-grounded SQL. Use when the chord-analyst MCP server is connected (mcp__chord_analyst__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any saved/canonical query. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. Claude retrieves full context (DDL, instructions, memory, examples) before writing SQL.
+---
+
+# Chord Analyst — retrieval-grounded SQL workflow
+
+You have access to `mcp__chord_analyst__*` tools exposed by the chord-analyst MCP
+server. Reach for them automatically — without being asked — whenever the user's
+request involves warehouse data, schema, saved queries, or product documentation.
+
+## Tools
+
+### Primary retrieval
+
+- **`get_sql_context`** — the most important tool. One call runs schema DDL
+  lookup, historical SQL examples, user-defined instructions, and memory in
+  parallel and returns a single structured payload:
+  `{schema_ddl, sql_pairs, instructions, memories}`.
+  - `schema_ddl`: exact column names and types — always use this before writing SQL.
+  - `instructions`: always-apply project conventions (test-order exclusion,
+    revenue/COGS definitions, required filters, join keys). Apply all that are
+    relevant; cite which you used and which you skipped (with reasoning).
+  - `sql_pairs`: few-shot examples grounding your SQL in patterns that have
+    worked before.
+
+### Supplemental retrieval
+
+- **`search_schema`** — semantic search over table descriptions. Useful for
+  exploring beyond the top-k tables returned by `get_sql_context`.
+- **`search_sql_pairs`** — additional historical Q&A examples beyond what
+  `get_sql_context` returns.
+- **`search_saved_views`** — canonical, user-blessed queries. Prefer an existing
+  view over writing new SQL if one covers the question.
+- **`search_instructions`** — targeted instruction lookup by scope (e.g.
+  `scope="chart"`). Covered by `get_sql_context` for the standard `sql` scope.
+- **`search_documentation`** — Chord Copilot user-guide pages. For
+  "how do I…" questions about the product itself.
+
+### Execution
+
+- **`execute_sql`** — run a read-only SELECT query (capped at 10 000 rows).
+  Pass `validate_only=True` to parse-check without executing.
+- **`preview_table`** — peek at up to 100 rows from a known table.
+  For shape/sanity checks, not analysis.
+
+## Workflow
+
+1. **`get_sql_context`** and **`search_saved_views`** in parallel — retrieval
+   bundle plus canonical view check in one round trip.
+2. **Draft SQL** grounded in `schema_ddl`, `instructions`, and `sql_pairs`. If
+   a saved view already answers the question, prefer it and cite its `view_id`.
+3. For non-trivial queries, **`execute_sql validate_only=True`** to catch errors
+   before execution.
+4. **`execute_sql`** to run and return rows.
+
+## Presenting the answer
+
+- **Cite instructions applied.** Name which instructions from `get_sql_context`
+  you followed and which you intentionally skipped, with reasoning.
+- **Name saved views.** If a view answered the question, cite its `view_id`.
+- **Surface errors verbatim.** Show the engine error before attempting a fix.
+
+## Failure modes
+
+- **MCP tools not available** — the `mcp__chord_analyst__*` tools are missing.
+  The chord-analyst MCP server isn't registered. Tell the user to run:
+  ```
+  claude mcp add chord-analyst --transport http https://mcp.<instance>.chord.co/mcp/analyst/ --scope user
+  ```
+
+- **Engine unreachable** — `execute_sql` / `preview_table` return a connection
+  error. Retrieval tools (`get_sql_context`, `search_saved_views`) may still
+  work — complete steps 1–3 and stop at "drafted SQL, ready to run once the
+  engine is up."

--- a/plugin/skills/copilot/SKILL.md
+++ b/plugin/skills/copilot/SKILL.md
@@ -1,30 +1,32 @@
 ---
 name: chord-copilot
-description: Answer data questions against the Chord warehouse by delegating to the Chord Hub pipeline end-to-end. Use when the chord-copilot MCP server is connected (mcp__chord_copilot__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any metric in the Chord data model. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. The Hub handles intent classification, SQL generation, warehouse execution, and narrative summary — Claude surfaces the result.
+description: Answer data questions against the Chord warehouse by delegating to the Chord GraphQL pipeline end-to-end. Use when the chord MCP server is connected (mcp__chord__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any metric in the Chord data model. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. The pipeline handles intent classification, SQL generation, warehouse execution, and narrative summary — Claude surfaces the result.
 ---
 
-# Chord Copilot — Hub pipeline workflow
+# Chord Copilot — GraphQL pipeline workflow
 
-You have access to `mcp__chord_copilot__*` tools exposed by the chord-copilot MCP
-server. Use them automatically whenever the user's request involves warehouse data.
+You have access to `mcp__chord__*` tools exposed by the chord MCP server.
+Use them automatically whenever the user's request involves warehouse data.
 
-The Hub pipeline is the same engine that powers the Chord Hub UI and the Chord
-Slack bot, so results are consistent across all surfaces.
+Use the Copilot-tier tools for this workflow: `ask` and `preview_table`.
+Do not call `get_sql_context`, `execute_sql`, or write SQL directly — the
+pipeline handles all of that.
+
+The `ask` tool calls wren-ui's GraphQL API directly, running the same pipeline
+that powers the Chord Hub UI and Slack bot. Results are consistent across all
+surfaces.
 
 ## Tools
 
-- **`ask`** — the primary tool. One call handles the full pipeline: intent
-  classification → SQL generation → warehouse execution → natural-language
-  summary. Returns one of:
-  - `{sql, summary, threadId}` — for data questions: the generated SQL, a
-    human-readable answer, and a thread ID for follow-ups.
-  - `{type: "NON_SQL_QUERY", explanation, threadId}` — for general questions
-    the Hub can't answer with SQL.
-  Pass `thread_id` to continue an existing conversation thread.
+- **`ask`** — the primary tool. One call handles the full pipeline: SQL
+  generation → warehouse execution → natural-language summary. Returns one of:
+  - `{sql, summary, threadId}` — for data questions.
+  - `{type: "NON_SQL_QUERY", explanation, threadId: null}` — for general
+    questions the pipeline can't answer with SQL.
+  Pass `thread_id` (integer) to continue an existing conversation thread.
 
 - **`preview_table`** — peek at up to 100 rows from a known table. Use for
-  quick shape checks when the user wants to see example data without asking
-  a full question.
+  quick shape checks without asking a full question.
 
 ## Workflow
 
@@ -32,27 +34,27 @@ Slack bot, so results are consistent across all surfaces.
 2. If the response contains `sql` and `summary`:
    - Present the `summary` as the answer.
    - Offer to show the underlying SQL if the user wants to verify it.
-   - Pass the returned `threadId` as `thread_id` in any follow-up `ask` call
-     to maintain conversation context.
+   - Pass the returned `threadId` as `thread_id` in any follow-up `ask` call.
 3. If the response is `NON_SQL_QUERY`: present the `explanation` directly.
 
 ## Follow-up conversations
 
-Thread context is maintained server-side via `threadId`. Always pass it back:
+Thread context is maintained server-side. Always pass the integer `threadId`
+back as `thread_id` for follow-ups:
 
 ```
-first answer  → {sql, summary, threadId: "t1"}
-follow-up     → ask("And last month?", thread_id="t1")
+first call    → ask("How many orders last month?")
+               ← {sql, summary, threadId: 42}
+follow-up     → ask("And last quarter?", thread_id=42)
 ```
 
 ## Failure modes
 
-- **MCP tools not available** — the `mcp__chord_copilot__*` tools are missing.
-  The chord-copilot MCP server isn't registered. Tell the user to run:
+- **MCP tools not available** — the `mcp__chord__*` tools are missing.
+  The chord MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord-copilot --transport http https://mcp.<instance>.chord.co/mcp/copilot/ --scope user
+  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
   ```
 
-- **`ask` returns Hub not configured** — the MCP server is running without
-  `WREN_UI_URL`. The Copilot pipeline is unavailable; tell the user to check
-  their deployment configuration.
+- **`ask` returns error about wren-ui not configured** — the MCP server is
+  running without `WREN_UI_URL`. Tell the user to check their deployment config.

--- a/plugin/skills/copilot/SKILL.md
+++ b/plugin/skills/copilot/SKILL.md
@@ -1,71 +1,140 @@
 ---
 name: chord-copilot
-description: Answer data questions against the Chord warehouse using the chord MCP retrieval and execution tools. Use when the user asks about warehouse data, schema, metrics, revenue, customers, orders, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any saved/canonical query — i.e. anything that would be answered by SQL against the Chord data model. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. Walks the agent through the default retrieval-grounded SQL workflow: search_schema → search_saved_views / search_sql_pairs → search_instructions → draft SQL → execute_sql. Requires the chord-copilot MCP server to be connected; if the mcp__chord__* tools are not available, fall back to the user's normal workflow and tell them to connect the server.
+description: Answer data questions against the Chord warehouse using the chord MCP tools. Use when the user asks about warehouse data, schema, metrics, revenue, customers, orders, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any saved/canonical query — anything that would be answered by SQL against the Chord data model. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. Supports two modes: Analyst (Claude retrieves context and writes SQL via get_sql_context + execute_sql) and Copilot (full Hub pipeline delegated via ask). Requires the chord-copilot MCP server to be connected; if the mcp__chord__* tools are not available, tell the user to connect the server.
 ---
 
-# Chord Copilot — data-question workflow
+# Chord Copilot — data-question workflows
 
-You have access to a set of `mcp__chord__*` tools exposed by the chord-copilot
-MCP server. Reach for them automatically — without being asked — whenever the
-user's request involves the project's warehouse data, schema, saved queries,
-or product documentation. Do not fall back to hand-written SQL or guess at
-table names when these tools are available.
+You have access to `mcp__chord__*` tools exposed by the chord-copilot MCP server.
+Reach for them automatically — without being asked — whenever the user's request
+involves warehouse data, schema, saved queries, or product documentation. Do not
+fall back to hand-written SQL or guess at table names when these tools are available.
 
-## When to use which tool
+Two modes are available. Default to **Analyst** mode; switch to **Copilot** mode
+when the user wants a packaged answer with a natural-language summary.
 
-- **`search_schema`** — first stop for any data question. Discover which
-  tables exist and what they contain before writing SQL.
-- **`search_sql_pairs`** — find past question/SQL pairs that resemble the
-  user's question. Useful as few-shot grounding before drafting new SQL.
+---
+
+## Tool reference
+
+### Retrieval bundle
+
+- **`get_sql_context`** — the primary retrieval tool. One call runs schema DDL
+  lookup, historical SQL examples, user-defined instructions, and memory in
+  parallel and returns a single structured payload:
+  `{schema_ddl, sql_pairs, instructions, memories}`. Use this before writing any
+  SQL — `schema_ddl` gives exact column names and types, `instructions` contain
+  always-apply project conventions (filters, joins, revenue/COGS rules,
+  test-order exclusion), and `sql_pairs` provide few-shot examples.
+
+### Individual retrieval (targeted lookups)
+
+- **`search_schema`** — semantic search over table descriptions. Useful for
+  exploring what data exists or finding tables beyond the top-k returned by
+  `get_sql_context`.
+- **`search_sql_pairs`** — find past question/SQL pairs. Use when you need
+  additional examples not covered by `get_sql_context`.
 - **`search_saved_views`** — check whether a user-blessed canonical query
   already answers the question. Prefer an existing view over inventing SQL.
-- **`search_instructions`** — pull any always-apply SQL guidance the user
-  has stored (filters, joins, casing rules, revenue/COGS conventions,
-  test-order exclusion). Run this before finalizing SQL.
+  Run this as a separate step alongside or after `get_sql_context`.
+- **`search_instructions`** — pull always-apply SQL guidance. Covered by
+  `get_sql_context` in the standard workflow; call this directly only for
+  targeted scope queries (e.g. `scope="chart"`).
 - **`search_documentation`** — for "how do I…" questions about the Chord
   Copilot product itself (global, not project-scoped).
+
+### Execution
+
 - **`preview_table`** — peek at a handful of rows from a known table.
   Capped at 100 rows; use for shape/sanity checks, not analysis.
 - **`execute_sql`** — run a read-only query (SELECT/UNION/INTERSECT/EXCEPT
-  only; capped at 10000 rows). Pass `validate_only=True` to parse-check
+  only; capped at 10 000 rows). Pass `validate_only=True` to parse-check
   without executing.
 
-## Default workflow
+### Hub pipeline
 
-For a data question:
+- **`ask`** — delegates the full pipeline to the Chord Hub: SQL generation →
+  warehouse execution → natural-language summary in one call. Returns
+  `{sql, summary, threadId}` for data questions or
+  `{type: "NON_SQL_QUERY", explanation, threadId}` for general questions.
+  Pass `thread_id` to continue an existing conversation thread.
 
-1. `search_schema` — discover relevant tables.
-2. `search_saved_views` and `search_sql_pairs` — in parallel, look for a
-   canonical query or close prior example.
-3. `search_instructions` — pull always-apply SQL guidance.
-4. Draft SQL grounded in the above.
-5. `execute_sql` (optionally with `validate_only=True` first for non-trivial
-   queries) to return rows.
+---
 
-Run independent retrieval steps in parallel.
+## Mode 1 — Analyst (Claude writes SQL)
+
+**Use this by default.** Claude retrieves context from the warehouse data model
+and then writes SQL grounded in that context.
+
+1. **`get_sql_context`** — single call, returns schema DDL, SQL examples,
+   instructions, and memory. Supplies everything needed to write correct SQL.
+2. **`search_saved_views`** — check for a canonical user-blessed query that
+   already answers the question. Prefer it over writing new SQL if one exists.
+3. **Draft SQL** grounded in the context from steps 1–2. For non-trivial
+   queries, call `execute_sql` with `validate_only=True` first.
+4. **`execute_sql`** — run the query and return rows.
+
+Run step 2 in parallel with step 1 since they're independent.
+
+---
+
+## Mode 2 — Copilot (Hub pipeline)
+
+**Use when the user wants a packaged answer** — SQL, results, and a
+natural-language summary — without stepping through the workflow manually.
+Also use when the user says "ask Chord" or "use the Hub".
+
+1. **`ask(question, thread_id?)`** — one call that handles the full pipeline.
+2. If the response contains `sql` and `summary`: present the summary as the
+   answer. Offer to show the SQL or run follow-up questions. Pass the returned
+   `threadId` as `thread_id` in any follow-up `ask` call.
+3. If the response is `NON_SQL_QUERY`: present the `explanation` field directly.
+
+---
+
+## Choosing a mode
+
+| Situation | Mode |
+|-----------|------|
+| User asks a data question and wants to see/verify the SQL | Analyst |
+| Multi-step or iterative query refinement | Analyst |
+| Complex joins, window functions, or custom logic | Analyst |
+| User wants a quick packaged answer with a summary | Copilot |
+| Follow-up questions in a thread ("and last month?") | Copilot |
+| User says "ask Chord" / "use the Hub" | Copilot |
+
+---
 
 ## How to present the answer
 
-- Cite which instructions you applied — and which you intentionally
-  skipped, with reasoning. (Example: "Used plain `NET_REVENUE` because
-  the user asked for 'revenue', not 'net revenue' — instruction #37
-  reserves the COGS+shipping formula for explicit 'net revenue' asks.")
-- If a saved view answered the question, name the `view_id` so the user
-  can find it in Copilot.
-- If the engine returns an error, surface the error text verbatim before
-  attempting a fix — the user often recognizes it.
+- **Cite instructions applied.** Name which instructions from `get_sql_context`
+  you followed — and which you intentionally skipped, with reasoning.
+  (Example: "Used `NET_REVENUE` because the user asked for 'revenue', not
+  'net revenue' — instruction #37 reserves the COGS+shipping formula for
+  explicit 'net revenue' asks.")
+- **Name saved views.** If a saved view answered the question, cite its
+  `view_id` so the user can find it in the Hub.
+- **Surface errors verbatim.** If the engine returns an error, show the error
+  text before attempting a fix — the user often recognizes it.
+
+---
 
 ## Failure modes
 
-- **MCP tools not available**: the `mcp__chord__*` tools are missing from
-  the tool list. The chord-copilot MCP server isn't registered with
-  Claude Code. Tell the user to run:
+- **MCP tools not available** — the `mcp__chord__*` tools are missing from the
+  tool list. The chord-copilot MCP server isn't registered with Claude Code.
+  Tell the user to run:
   ```
-  claude mcp add chord-copilot --transport http http://localhost:5555/mcp/ --scope user
+  claude mcp add chord-copilot --transport http https://mcp.<instance>.copilot.chord.co/mcp/ --scope user
   ```
-  (replacing the URL if their wren-ai-service runs elsewhere). Fall back
-  to whatever workflow they normally use until they do.
-- **Engine unreachable**: `execute_sql` / `preview_table` return a
-  connection error (typically localhost:3000 unreachable). The retrieval
-  tools may still work — complete steps 1–4 and stop at "drafted SQL,
+  (replacing `<instance>` with their tenant slug). Fall back to whatever
+  workflow they normally use until then.
+
+- **`ask` returns an error about Hub not configured** — the MCP server is
+  running without `WREN_UI_URL` set. This means the Copilot mode is unavailable;
+  switch to Analyst mode instead.
+
+- **Engine unreachable** — `execute_sql` / `preview_table` return a connection
+  error. The retrieval tools (`get_sql_context`, `search_saved_views`) may still
+  work — complete steps 1–3 of the Analyst workflow and stop at "drafted SQL,
   ready to run once the engine is up."

--- a/plugin/skills/copilot/SKILL.md
+++ b/plugin/skills/copilot/SKILL.md
@@ -1,140 +1,58 @@
 ---
 name: chord-copilot
-description: Answer data questions against the Chord warehouse using the chord MCP tools. Use when the user asks about warehouse data, schema, metrics, revenue, customers, orders, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any saved/canonical query — anything that would be answered by SQL against the Chord data model. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. Supports two modes: Analyst (Claude retrieves context and writes SQL via get_sql_context + execute_sql) and Copilot (full Hub pipeline delegated via ask). Requires the chord-copilot MCP server to be connected; if the mcp__chord__* tools are not available, tell the user to connect the server.
+description: Answer data questions against the Chord warehouse by delegating to the Chord Hub pipeline end-to-end. Use when the chord-copilot MCP server is connected (mcp__chord_copilot__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, attribution, Shopify, Klaviyo, Iterable, or any metric in the Chord data model. Triggers include 'how many', 'show me', 'top N', 'last month', 'last quarter', 'trend', 'breakdown', 'compare', 'revenue', 'orders', 'customers'. The Hub handles intent classification, SQL generation, warehouse execution, and narrative summary — Claude surfaces the result.
 ---
 
-# Chord Copilot — data-question workflows
+# Chord Copilot — Hub pipeline workflow
 
-You have access to `mcp__chord__*` tools exposed by the chord-copilot MCP server.
-Reach for them automatically — without being asked — whenever the user's request
-involves warehouse data, schema, saved queries, or product documentation. Do not
-fall back to hand-written SQL or guess at table names when these tools are available.
+You have access to `mcp__chord_copilot__*` tools exposed by the chord-copilot MCP
+server. Use them automatically whenever the user's request involves warehouse data.
 
-Two modes are available. Default to **Analyst** mode; switch to **Copilot** mode
-when the user wants a packaged answer with a natural-language summary.
+The Hub pipeline is the same engine that powers the Chord Hub UI and the Chord
+Slack bot, so results are consistent across all surfaces.
 
----
+## Tools
 
-## Tool reference
-
-### Retrieval bundle
-
-- **`get_sql_context`** — the primary retrieval tool. One call runs schema DDL
-  lookup, historical SQL examples, user-defined instructions, and memory in
-  parallel and returns a single structured payload:
-  `{schema_ddl, sql_pairs, instructions, memories}`. Use this before writing any
-  SQL — `schema_ddl` gives exact column names and types, `instructions` contain
-  always-apply project conventions (filters, joins, revenue/COGS rules,
-  test-order exclusion), and `sql_pairs` provide few-shot examples.
-
-### Individual retrieval (targeted lookups)
-
-- **`search_schema`** — semantic search over table descriptions. Useful for
-  exploring what data exists or finding tables beyond the top-k returned by
-  `get_sql_context`.
-- **`search_sql_pairs`** — find past question/SQL pairs. Use when you need
-  additional examples not covered by `get_sql_context`.
-- **`search_saved_views`** — check whether a user-blessed canonical query
-  already answers the question. Prefer an existing view over inventing SQL.
-  Run this as a separate step alongside or after `get_sql_context`.
-- **`search_instructions`** — pull always-apply SQL guidance. Covered by
-  `get_sql_context` in the standard workflow; call this directly only for
-  targeted scope queries (e.g. `scope="chart"`).
-- **`search_documentation`** — for "how do I…" questions about the Chord
-  Copilot product itself (global, not project-scoped).
-
-### Execution
-
-- **`preview_table`** — peek at a handful of rows from a known table.
-  Capped at 100 rows; use for shape/sanity checks, not analysis.
-- **`execute_sql`** — run a read-only query (SELECT/UNION/INTERSECT/EXCEPT
-  only; capped at 10 000 rows). Pass `validate_only=True` to parse-check
-  without executing.
-
-### Hub pipeline
-
-- **`ask`** — delegates the full pipeline to the Chord Hub: SQL generation →
-  warehouse execution → natural-language summary in one call. Returns
-  `{sql, summary, threadId}` for data questions or
-  `{type: "NON_SQL_QUERY", explanation, threadId}` for general questions.
+- **`ask`** — the primary tool. One call handles the full pipeline: intent
+  classification → SQL generation → warehouse execution → natural-language
+  summary. Returns one of:
+  - `{sql, summary, threadId}` — for data questions: the generated SQL, a
+    human-readable answer, and a thread ID for follow-ups.
+  - `{type: "NON_SQL_QUERY", explanation, threadId}` — for general questions
+    the Hub can't answer with SQL.
   Pass `thread_id` to continue an existing conversation thread.
 
----
+- **`preview_table`** — peek at up to 100 rows from a known table. Use for
+  quick shape checks when the user wants to see example data without asking
+  a full question.
 
-## Mode 1 — Analyst (Claude writes SQL)
+## Workflow
 
-**Use this by default.** Claude retrieves context from the warehouse data model
-and then writes SQL grounded in that context.
+1. **`ask(question, thread_id?)`** — pass the user's question as-is.
+2. If the response contains `sql` and `summary`:
+   - Present the `summary` as the answer.
+   - Offer to show the underlying SQL if the user wants to verify it.
+   - Pass the returned `threadId` as `thread_id` in any follow-up `ask` call
+     to maintain conversation context.
+3. If the response is `NON_SQL_QUERY`: present the `explanation` directly.
 
-1. **`get_sql_context`** — single call, returns schema DDL, SQL examples,
-   instructions, and memory. Supplies everything needed to write correct SQL.
-2. **`search_saved_views`** — check for a canonical user-blessed query that
-   already answers the question. Prefer it over writing new SQL if one exists.
-3. **Draft SQL** grounded in the context from steps 1–2. For non-trivial
-   queries, call `execute_sql` with `validate_only=True` first.
-4. **`execute_sql`** — run the query and return rows.
+## Follow-up conversations
 
-Run step 2 in parallel with step 1 since they're independent.
+Thread context is maintained server-side via `threadId`. Always pass it back:
 
----
-
-## Mode 2 — Copilot (Hub pipeline)
-
-**Use when the user wants a packaged answer** — SQL, results, and a
-natural-language summary — without stepping through the workflow manually.
-Also use when the user says "ask Chord" or "use the Hub".
-
-1. **`ask(question, thread_id?)`** — one call that handles the full pipeline.
-2. If the response contains `sql` and `summary`: present the summary as the
-   answer. Offer to show the SQL or run follow-up questions. Pass the returned
-   `threadId` as `thread_id` in any follow-up `ask` call.
-3. If the response is `NON_SQL_QUERY`: present the `explanation` field directly.
-
----
-
-## Choosing a mode
-
-| Situation | Mode |
-|-----------|------|
-| User asks a data question and wants to see/verify the SQL | Analyst |
-| Multi-step or iterative query refinement | Analyst |
-| Complex joins, window functions, or custom logic | Analyst |
-| User wants a quick packaged answer with a summary | Copilot |
-| Follow-up questions in a thread ("and last month?") | Copilot |
-| User says "ask Chord" / "use the Hub" | Copilot |
-
----
-
-## How to present the answer
-
-- **Cite instructions applied.** Name which instructions from `get_sql_context`
-  you followed — and which you intentionally skipped, with reasoning.
-  (Example: "Used `NET_REVENUE` because the user asked for 'revenue', not
-  'net revenue' — instruction #37 reserves the COGS+shipping formula for
-  explicit 'net revenue' asks.")
-- **Name saved views.** If a saved view answered the question, cite its
-  `view_id` so the user can find it in the Hub.
-- **Surface errors verbatim.** If the engine returns an error, show the error
-  text before attempting a fix — the user often recognizes it.
-
----
+```
+first answer  → {sql, summary, threadId: "t1"}
+follow-up     → ask("And last month?", thread_id="t1")
+```
 
 ## Failure modes
 
-- **MCP tools not available** — the `mcp__chord__*` tools are missing from the
-  tool list. The chord-copilot MCP server isn't registered with Claude Code.
-  Tell the user to run:
+- **MCP tools not available** — the `mcp__chord_copilot__*` tools are missing.
+  The chord-copilot MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord-copilot --transport http https://mcp.<instance>.copilot.chord.co/mcp/ --scope user
+  claude mcp add chord-copilot --transport http https://mcp.<instance>.chord.co/mcp/copilot/ --scope user
   ```
-  (replacing `<instance>` with their tenant slug). Fall back to whatever
-  workflow they normally use until then.
 
-- **`ask` returns an error about Hub not configured** — the MCP server is
-  running without `WREN_UI_URL` set. This means the Copilot mode is unavailable;
-  switch to Analyst mode instead.
-
-- **Engine unreachable** — `execute_sql` / `preview_table` return a connection
-  error. The retrieval tools (`get_sql_context`, `search_saved_views`) may still
-  work — complete steps 1–3 of the Analyst workflow and stop at "drafted SQL,
-  ready to run once the engine is up."
+- **`ask` returns Hub not configured** — the MCP server is running without
+  `WREN_UI_URL`. The Copilot pipeline is unavailable; tell the user to check
+  their deployment configuration.

--- a/plugin/skills/explorer/SKILL.md
+++ b/plugin/skills/explorer/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: chord-explorer
+description: Browse and discover the Chord data model — tables, saved views, and documentation — without writing SQL. Use when the chord-explorer MCP server is connected (mcp__chord_explorer__* tools are available) and the user wants to understand what data exists, find canonical queries, or get oriented in the schema. Triggers include 'what tables', 'what data do we have', 'show me the schema', 'find a view for', 'what is in', 'how is X defined', 'browse', 'explore', 'documentation'.
+---
+
+# Chord Explorer — schema discovery workflow
+
+You have access to `mcp__chord_explorer__*` tools exposed by the chord-explorer MCP
+server. Use them automatically when the user wants to explore, understand, or
+navigate the data model — not to answer a specific analytical question.
+
+Explorer is read-only discovery: no SQL execution. For analytical questions,
+the user needs the Analyst or Copilot tier.
+
+## Tools
+
+- **`search_schema`** — semantic search over table descriptions. Returns table
+  names, short descriptions, and similarity scores. Use to answer "what tables
+  exist for X?" or to orient the user in an unfamiliar dataset.
+
+- **`search_saved_views`** — find canonical, user-blessed named queries that
+  match the user's topic. Returns the originating question, a short summary,
+  the SQL behind the view, and its `view_id`. Use to surface answers that have
+  already been codified.
+
+- **`preview_table`** — peek at up to 100 rows from a known table. Useful for
+  understanding the shape and content of a table without committing to a query.
+
+- **`search_documentation`** — search the Chord Copilot user-guide for pages
+  matching the query. For "how do I…" questions about the Copilot product.
+
+## Workflow
+
+**Exploring what data exists:**
+1. `search_schema` with the user's topic — identify relevant tables.
+2. `preview_table` on interesting tables to show example rows.
+3. `search_saved_views` to surface any canonical queries in this area.
+
+**Finding a saved view:**
+1. `search_saved_views` — primary tool. The `sql` field shows exactly how
+   the metric was computed; cite the `view_id` so the user can find it in
+   the Hub.
+
+**Product documentation:**
+1. `search_documentation` — returns page paths and content excerpts.
+
+## Presenting findings
+
+- Summarize what tables are available and what they contain, linking to
+  relevant saved views by `view_id`.
+- Be explicit about what Explorer cannot do: if the user wants to run a
+  query or get numbers, they need the Analyst or Copilot tier.
+
+## Failure modes
+
+- **MCP tools not available** — the `mcp__chord_explorer__*` tools are missing.
+  The chord-explorer MCP server isn't registered. Tell the user to run:
+  ```
+  claude mcp add chord-explorer --transport http https://mcp.<instance>.chord.co/mcp/explorer/ --scope user
+  ```

--- a/plugin/skills/explorer/SKILL.md
+++ b/plugin/skills/explorer/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: chord-explorer
-description: Browse and discover the Chord data model — tables, saved views, and documentation — without writing SQL. Use when the chord-explorer MCP server is connected (mcp__chord_explorer__* tools are available) and the user wants to understand what data exists, find canonical queries, or get oriented in the schema. Triggers include 'what tables', 'what data do we have', 'show me the schema', 'find a view for', 'what is in', 'how is X defined', 'browse', 'explore', 'documentation'.
+description: Browse and discover the Chord data model — tables, saved views, and documentation — without writing SQL. Use when the chord MCP server is connected (mcp__chord__* tools are available) and the user wants to understand what data exists, find canonical queries, or get oriented in the schema. Triggers include 'what tables', 'what data do we have', 'show me the schema', 'find a view for', 'what is in', 'how is X defined', 'browse', 'explore', 'documentation'.
 ---
 
 # Chord Explorer — schema discovery workflow
 
-You have access to `mcp__chord_explorer__*` tools exposed by the chord-explorer MCP
-server. Use them automatically when the user wants to explore, understand, or
-navigate the data model — not to answer a specific analytical question.
+You have access to `mcp__chord__*` tools exposed by the chord MCP server.
+Use them automatically when the user wants to explore, understand, or navigate
+the data model rather than answer a specific analytical question.
 
-Explorer is read-only discovery: no SQL execution. For analytical questions,
-the user needs the Analyst or Copilot tier.
+Use the Explorer-tier tools for this workflow: `search_schema`,
+`search_saved_views`, `preview_table`, and `search_documentation`.
+Do not call `execute_sql`, `get_sql_context`, or `ask` — Explorer is
+discovery only, not analysis.
 
 ## Tools
 
@@ -20,14 +22,13 @@ the user needs the Analyst or Copilot tier.
 
 - **`search_saved_views`** — find canonical, user-blessed named queries that
   match the user's topic. Returns the originating question, a short summary,
-  the SQL behind the view, and its `view_id`. Use to surface answers that have
-  already been codified.
+  the SQL behind the view, and its `view_id`.
 
 - **`preview_table`** — peek at up to 100 rows from a known table. Useful for
-  understanding the shape and content of a table without committing to a query.
+  understanding the shape and content of a table.
 
 - **`search_documentation`** — search the Chord Copilot user-guide for pages
-  matching the query. For "how do I…" questions about the Copilot product.
+  matching the query. For "how do I…" questions about the product itself.
 
 ## Workflow
 
@@ -38,23 +39,22 @@ the user needs the Analyst or Copilot tier.
 
 **Finding a saved view:**
 1. `search_saved_views` — primary tool. The `sql` field shows exactly how
-   the metric was computed; cite the `view_id` so the user can find it in
-   the Hub.
+   the metric is computed; cite the `view_id` so the user can find it in the Hub.
 
 **Product documentation:**
 1. `search_documentation` — returns page paths and content excerpts.
 
 ## Presenting findings
 
-- Summarize what tables are available and what they contain, linking to
-  relevant saved views by `view_id`.
-- Be explicit about what Explorer cannot do: if the user wants to run a
-  query or get numbers, they need the Analyst or Copilot tier.
+- Summarize which tables are available and what they contain.
+- Link to relevant saved views by `view_id`.
+- Be explicit about what Explorer cannot do: if the user wants to run a query
+  or get numbers, they need the Analyst or Copilot tier.
 
 ## Failure modes
 
-- **MCP tools not available** — the `mcp__chord_explorer__*` tools are missing.
-  The chord-explorer MCP server isn't registered. Tell the user to run:
+- **MCP tools not available** — the `mcp__chord__*` tools are missing.
+  The chord MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord-explorer --transport http https://mcp.<instance>.chord.co/mcp/explorer/ --scope user
+  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
   ```

--- a/plugin/skills/raw/SKILL.md
+++ b/plugin/skills/raw/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: chord-raw
+description: Answer data questions against the Chord warehouse using only table descriptions and SQL execution. Use when the chord-raw MCP server is connected (mcp__chord_raw__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, or any metric that lives in the Chord data model. Claude discovers tables via search_schema and writes SQL itself with no additional context.
+---
+
+# Chord Raw — data-question workflow
+
+You have access to `mcp__chord_raw__*` tools exposed by the chord-raw MCP server.
+Use them automatically whenever the user's request involves warehouse data or metrics.
+
+## Tools
+
+- **`search_schema`** — semantic search over table descriptions. Returns table
+  names, short descriptions, and similarity scores. Use this to discover which
+  tables are relevant before writing SQL. You will not get column DDL — reason
+  from common naming conventions and validate with `execute_sql validate_only=True`
+  before running non-trivial queries.
+
+- **`execute_sql`** — run a read-only SELECT query against the warehouse. Only
+  SELECT/UNION/INTERSECT/EXCEPT are accepted; capped at 10 000 rows.
+  Pass `validate_only=True` to parse-check without executing.
+
+## Workflow
+
+1. **`search_schema`** — find tables relevant to the question.
+2. **Draft SQL** from the table descriptions. Use common Snowflake column-naming
+   conventions. For non-trivial queries, call `execute_sql` with
+   `validate_only=True` first to catch binding errors early.
+3. **`execute_sql`** — run the query and return rows.
+
+## Presenting the answer
+
+- Show the SQL you wrote alongside the results so the user can verify it.
+- If the engine returns an error, show it verbatim before attempting a fix.
+- If a query binding fails (unknown column), try a narrower `search_schema` call
+  to find the correct column name, then revise.
+
+## Failure modes
+
+- **MCP tools not available** — the `mcp__chord_raw__*` tools are missing.
+  The chord-raw MCP server isn't registered with Claude Code. Tell the user to run:
+  ```
+  claude mcp add chord-raw --transport http https://mcp.<instance>.chord.co/mcp/raw/ --scope user
+  ```

--- a/plugin/skills/raw/SKILL.md
+++ b/plugin/skills/raw/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: chord-raw
-description: Answer data questions against the Chord warehouse using only table descriptions and SQL execution. Use when the chord-raw MCP server is connected (mcp__chord_raw__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, or any metric that lives in the Chord data model. Claude discovers tables via search_schema and writes SQL itself with no additional context.
+description: Answer data questions against the Chord warehouse using only table descriptions and SQL execution. Use when the chord MCP server is connected (mcp__chord__* tools are available) and the user asks about warehouse data — revenue, orders, customers, products, subscriptions, sessions, or any metric that lives in the Chord data model. Claude discovers tables via search_schema and writes SQL itself with no additional context.
 ---
 
 # Chord Raw — data-question workflow
 
-You have access to `mcp__chord_raw__*` tools exposed by the chord-raw MCP server.
-Use them automatically whenever the user's request involves warehouse data or metrics.
+You have access to `mcp__chord__*` tools exposed by the chord MCP server.
+
+Use only the Raw-tier tools for this workflow: `search_schema` and `execute_sql`.
+Do not call `get_sql_context`, `ask`, or other tools — they are not part of the
+Raw tier.
 
 ## Tools
 
@@ -37,8 +40,8 @@ Use them automatically whenever the user's request involves warehouse data or me
 
 ## Failure modes
 
-- **MCP tools not available** — the `mcp__chord_raw__*` tools are missing.
-  The chord-raw MCP server isn't registered with Claude Code. Tell the user to run:
+- **MCP tools not available** — the `mcp__chord__*` tools are missing.
+  The chord MCP server isn't registered with Claude Code. Tell the user to run:
   ```
-  claude mcp add chord-raw --transport http https://mcp.<instance>.chord.co/mcp/raw/ --scope user
+  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
   ```


### PR DESCRIPTION
## Summary

Replaces the single `chord-copilot` skill (which mixed Analyst and Copilot modes) with four purpose-built skills — one per MCP endpoint tier introduced in chordcommerce/chord-ai#218.

Each skill references the correct `mcp__chord_<tier>__*` tool namespace so Claude auto-triggers against the right endpoint and knows exactly which workflow to follow.

## Skills

| Skill | MCP server | Tools | Workflow |
|-------|-----------|-------|---------|
| `chord-raw` | `/mcp/raw` | `search_schema`, `execute_sql` | Discover tables → write SQL from descriptions → execute |
| `chord-analyst` | `/mcp/analyst` | `get_sql_context` + full suite | `get_sql_context` + `search_saved_views` in parallel → draft SQL → execute |
| `chord-copilot` | `/mcp/copilot` | `ask`, `preview_table` | Single `ask()` call; Hub handles full pipeline |
| `chord-explorer` | `/mcp/explorer` | `search_schema`, `search_saved_views`, `preview_table`, `search_documentation` | Discovery only, no SQL |

## Test plan

- [ ] Install each skill, connect the corresponding MCP endpoint, and confirm Claude auto-triggers on a warehouse data question
- [ ] Verify `chord-copilot` routes through `ask` and surfaces `summary` + `threadId`
- [ ] Verify `chord-analyst` calls `get_sql_context` before writing SQL
- [ ] Verify `chord-explorer` never calls `execute_sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)