### PR TITLE
Update skill MCP registration URL to wren-ai-service (port 5555)

### DIFF
--- a/plugin/skills/analyst/SKILL.md
+++ b/plugin/skills/analyst/SKILL.md
@@ -68,7 +68,9 @@ Copilot tier. Claude writes SQL here; Chord provides the context.
 - **MCP tools not available** — the `mcp__chord__*` tools are missing.
   The chord MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
+  # local dev (wren-ai-service):
+  claude mcp add chord --transport http http://localhost:5555/mcp/ --scope user
+  # deployed — use your wren-ai-service URL:
   ```
 
 - **Engine unreachable** — `execute_sql` / `preview_table` return a connection

--- a/plugin/skills/copilot/SKILL.md
+++ b/plugin/skills/copilot/SKILL.md
@@ -53,7 +53,9 @@ follow-up     → ask("And last quarter?", thread_id=42)
 - **MCP tools not available** — the `mcp__chord__*` tools are missing.
   The chord MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
+  # local dev (wren-ai-service):
+  claude mcp add chord --transport http http://localhost:5555/mcp/ --scope user
+  # deployed — use your wren-ai-service URL:
   ```
 
 - **`ask` returns error about wren-ui not configured** — the MCP server is

--- a/plugin/skills/explorer/SKILL.md
+++ b/plugin/skills/explorer/SKILL.md
@@ -56,5 +56,7 @@ discovery only, not analysis.
 - **MCP tools not available** — the `mcp__chord__*` tools are missing.
   The chord MCP server isn't registered. Tell the user to run:
   ```
-  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
+  # local dev (wren-ai-service):
+  claude mcp add chord --transport http http://localhost:5555/mcp/ --scope user
+  # deployed — use your wren-ai-service URL:
   ```

--- a/plugin/skills/raw/SKILL.md
+++ b/plugin/skills/raw/SKILL.md
@@ -43,5 +43,7 @@ Raw tier.
 - **MCP tools not available** — the `mcp__chord__*` tools are missing.
   The chord MCP server isn't registered with Claude Code. Tell the user to run:
   ```
-  claude mcp add chord --transport http https://mcp.<instance>.chord.co/mcp/ --scope user
+  # local dev (wren-ai-service):
+  claude mcp add chord --transport http http://localhost:5555/mcp/ --scope user
+  # deployed — use your wren-ai-service URL:
   ```


### PR DESCRIPTION
## Summary

- MCP is now embedded in `wren-ai-service` (port 5555) instead of the standalone `chord-mcp` service (port 5556)
- Updates all four skills (`chord-raw`, `chord-analyst`, `chord-copilot`, `chord-explorer`) to reference the correct local dev URL
- Adds a note that deployed instances should use the `wren-ai-service` host URL

## Test plan

- [ ] Install skills and register: `claude mcp add chord --transport http http://localhost:5555/mcp/ --scope user`
- [ ] Verify `mcp__chord__*` tools appear in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)